### PR TITLE
feat: Autoscaling and SES support

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -1,0 +1,114 @@
+resource "aws_iam_role" "keycloak-ecs-autoscale-role" {
+  name = "keycloak-ecs-scale-application"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "application-autoscaling.amazonaws.com"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "keycloak-ecs-autoscale" {
+  role       = aws_iam_role.keycloak-ecs-autoscale-role.id
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole"
+}
+
+
+# CLOUDWATCH ALARM to monitor the memory utilization of a service
+resource "aws_cloudwatch_metric_alarm" "keycloak-alarm-scale-down" {
+  alarm_description = "Scale down alarm for keycloak-service"
+  namespace         = "AWS/ECS"
+  alarm_name        = "keycloak-service-down"
+  alarm_actions     = [aws_appautoscaling_policy.keycloak-policy-scale-down.arn]
+
+  comparison_operator = var.autoscale["scale_down_comparison_operator"]
+  threshold           = var.autoscale["scale_down_threshold"]
+  evaluation_periods  = var.autoscale["evaluation_periods"]
+  metric_name         = var.autoscale["metric_name"]
+  period              = lookup(var.autoscale, "period", 180)
+  statistic           = lookup(var.autoscale, "statistic", "Average")
+  datapoints_to_alarm = lookup(var.autoscale, "datapoints_to_alarm", 3)
+
+  dimensions = {
+    ClusterName = local.keycloak_ecs_cluster_name
+    ServiceName = aws_ecs_service.keycloak-service.name
+  }
+}
+
+# CLOUDWATCH ALARM  to monitor memory utilization of a service
+resource "aws_cloudwatch_metric_alarm" "keycloak-alarm-scale-up" {
+  alarm_description = "Scale up alarm for keycloak-service"
+  namespace         = "AWS/ECS"
+  alarm_name        = "keycloak-service-up"
+  alarm_actions     = [aws_appautoscaling_policy.keycloak-policy-scale-up.arn]
+
+  comparison_operator = var.autoscale["scale_up_comparison_operator"]
+  threshold           = var.autoscale["scale_up_threshold"]
+  evaluation_periods  = var.autoscale["evaluation_periods"]
+  metric_name         = var.autoscale["metric_name"]
+  period              = lookup(var.autoscale, "period", 180)
+  statistic           = lookup(var.autoscale, "statistic", "Average")
+  datapoints_to_alarm = lookup(var.autoscale, "datapoints_to_alarm", 3)
+
+  dimensions = {
+    ClusterName = local.keycloak_ecs_cluster_name
+    ServiceName = aws_ecs_service.keycloak-service.name
+  }
+}
+
+resource "aws_appautoscaling_target" "keycloak-ecs-target" {
+  max_capacity       = lookup(var.autoscale, "autoscale_max_capacity", 4)
+  min_capacity       = lookup(var.autoscale, "service_desired_count", 2)
+  resource_id        = "service/keycloak-cluster/keycloak-service"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+  role_arn           = aws_iam_role.keycloak-ecs-autoscale-role.arn
+}
+
+# Set up the memory utilization policy for scale down when the cloudwatch alarm gets triggered.
+resource "aws_appautoscaling_policy" "keycloak-policy-scale-down" {
+  name               = "keycloak-service-down"
+  resource_id        = aws_appautoscaling_target.keycloak-ecs-target.resource_id
+  scalable_dimension = aws_appautoscaling_target.keycloak-ecs-target.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.keycloak-ecs-target.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = var.autoscale["adjustment_type"]
+    cooldown                = var.autoscale["cooldown"]
+    metric_aggregation_type = lookup(var.autoscale, "aggregation_type", "Average")
+
+    step_adjustment {
+      metric_interval_upper_bound = lookup(var.autoscale, "scale_down_interval_lower_bound", 0)
+      scaling_adjustment          = var.autoscale["scale_down_adjustment"]
+    }
+  }
+}
+
+# Set up the memory utilization policy for scale up when the cloudwatch alarm gets triggered.
+resource "aws_appautoscaling_policy" "keycloak-policy-scale-up" {
+  name               = "keycloak-service-up"
+  resource_id        = aws_appautoscaling_target.keycloak-ecs-target.resource_id
+  scalable_dimension = aws_appautoscaling_target.keycloak-ecs-target.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.keycloak-ecs-target.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = var.autoscale["adjustment_type"]
+    cooldown                = var.autoscale["cooldown"]
+    metric_aggregation_type = lookup(var.autoscale, "aggregation_type", "Average")
+
+    step_adjustment {
+      metric_interval_lower_bound = lookup(var.autoscale, "scale_up_interval_lower_bound", 1)
+      scaling_adjustment          = var.autoscale["scale_up_adjustment"]
+    }
+  }
+}
+

--- a/ses.tf
+++ b/ses.tf
@@ -1,0 +1,19 @@
+data "aws_iam_policy_document" "keycloak-ses-sender" {
+  statement {
+    actions   = ["ses:SendRawEmail", "ses:SendEmail"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "keycloak-ses-sender" {
+  name        = "keycloak-ses-sender"
+  description = "Allows sending of e-mails via Simple Email Service"
+  policy      = data.aws_iam_policy_document.keycloak-ses-sender.json
+}
+
+# Attach to ECS task role
+resource "aws_iam_role_policy_attachment" "keycloak-ses-send-mail-policy-attachment" {
+  role       = aws_iam_role.keycloak-ecs-execution-task-role.name
+  policy_arn = aws_iam_policy.keycloak-ses-sender.arn
+}
+

--- a/vars.tf
+++ b/vars.tf
@@ -43,9 +43,9 @@ variable "ecr_keycloak_image_tag" {
   default     = "latest"
 }
 
-variable "ecs_cluster_arn" {
+variable "ecs_cluster_name" {
   type        = string
-  description = "(optional) ARN of an existing ECS cluster. Defaults to creating a new ECS cluster"
+  description = "(optional) Name of an existing ECS cluster. Defaults to creating a new ECS cluster with the name 'keycloak-$${var.environment}-cluster'"
   default     = null
 }
 

--- a/vars.tf
+++ b/vars.tf
@@ -10,6 +10,12 @@ variable "acm_hostname" {
   default     = "keycloak.example.com"
 }
 
+variable "autoscale" {
+  description = "Autoscaling block"
+  type        = map(string)
+  default     = {}
+}
+
 variable "aws_region" {
   type        = string
   description = "AWS Region"


### PR DESCRIPTION
**Breaking change:** Replaces the `ecs_cluster_arn` variable with a similar `ecs_cluster_name` variable, in order to reference the cluster name in the autoscaling configuration.