### PR TITLE
feat: add support for multiple log drivers

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,3 +1,7 @@
+locals {
+  splunk_token_secret_arn_list = var.log_driver == "splunk" ? [local.keycloak_splunk_token_secret_arn] : []
+}
+
 data "aws_iam_policy_document" "assume_role_policy" {
   statement {
     actions = ["sts:AssumeRole"]
@@ -61,7 +65,7 @@ data "aws_iam_policy_document" "inline-keycloak-secretsmanager-doc" {
         aws_secretsmanager_secret.keycloak-admin-password.arn,
         aws_secretsmanager_secret.keycloak-database-password.arn,
       ],
-      aws_secretsmanager_secret.keycloak-splunk-token.*.arn
+      local.splunk_token_secret_arn_list
     )
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -56,9 +56,12 @@ data "aws_iam_policy_document" "inline-keycloak-secretsmanager-doc" {
   statement {
     actions = ["secretsmanager:GetSecretValue"]
     effect  = "Allow"
-    resources = [
-      aws_secretsmanager_secret.keycloak-admin-password.arn,
-      aws_secretsmanager_secret.keycloak-database-password.arn,
-    ]
+    resources = concat(
+      [
+        aws_secretsmanager_secret.keycloak-admin-password.arn,
+        aws_secretsmanager_secret.keycloak-database-password.arn,
+      ],
+      aws_secretsmanager_secret.keycloak-splunk-token.*.arn
+    )
   }
 }

--- a/keycloak.tf
+++ b/keycloak.tf
@@ -25,14 +25,6 @@ resource "aws_ecs_cluster" "keycloak-cluster" {
   tags = var.tags
 }
 
-resource "aws_cloudwatch_log_group" "keycloak-log-group" {
-  name              = "keycloak-${var.environment}-logs"
-  retention_in_days = 30
-
-  tags = var.tags
-}
-
-
 resource "aws_security_group" "keycloak-sg" {
   vpc_id = var.vpc_id
   name   = "keycloak-${var.environment}-sg"
@@ -85,14 +77,7 @@ resource "aws_ecs_task_definition" "keycloak-ecs-taskdef" {
         {"name":"DB_PASSWORD", "valueFrom":"${aws_secretsmanager_secret.keycloak-database-password.arn}"}
       ],
       "essential": true,
-      "logConfiguration": {
-        "logDriver": "awslogs",
-        "options": {
-          "awslogs-group": "${aws_cloudwatch_log_group.keycloak-log-group.id}",
-          "awslogs-region": "${var.aws_region}",
-          "awslogs-stream-prefix": "log"
-        }
-      },
+      "logConfiguration": ${local.log_configuration},
       "portMappings": [
         {
           "containerPort": 8080,

--- a/logconfiguration.tf
+++ b/logconfiguration.tf
@@ -1,0 +1,41 @@
+# define various task definition log configuration option blocks
+# and use a module var to switch between different log drivers
+locals {
+  all_log_configurations = {
+    awslogs = {
+      logDriver = "awslogs",
+      options = {
+        awslogs-group         = join("", aws_cloudwatch_log_group.keycloak-log-group.*.id),
+        awslogs-region        = var.aws_region,
+        awslogs-stream-prefix = "log"
+      }
+    },
+    splunk = {
+      logDriver = "splunk",
+      options = {
+        splunk-url    = var.splunk_http_endpoint,
+        splunk-index  = "keycloak-${var.environment}"
+        splunk-format = "raw"
+      }
+      secretOptions = [
+        {
+          name      = "splunk-token",
+          valueFrom = join("", aws_secretsmanager_secret.keycloak-splunk-token.*.arn)
+        }
+      ]
+    }
+  }
+
+  # the value of log_driver determines which of the above configuration blocks to use
+  log_configuration = jsonencode(local.all_log_configurations[var.log_driver])
+}
+
+# if log driver is CloudWatch, create log group
+resource "aws_cloudwatch_log_group" "keycloak-log-group" {
+  count = var.log_driver == "awslogs" ? 1 : 0
+
+  name              = "keycloak-${var.environment}-logs"
+  retention_in_days = 30
+
+  tags = var.tags
+}

--- a/logconfiguration.tf
+++ b/logconfiguration.tf
@@ -20,7 +20,7 @@ locals {
       secretOptions = [
         {
           name      = "splunk-token",
-          valueFrom = join("", aws_secretsmanager_secret.keycloak-splunk-token.*.arn)
+          valueFrom = local.keycloak_splunk_token_secret_arn
         }
       ]
     }

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,3 +1,7 @@
+locals {
+  keycloak_splunk_token_secret_arn = var.splunk_token_secret_arn == null ? join("", aws_secretsmanager_secret.keycloak-splunk-token.*.arn) : var.splunk_token_secret_arn
+}
+
 resource "aws_secretsmanager_secret" "keycloak-admin-password" {
   name = "keycloak-${var.environment}-admin-password"
 
@@ -12,7 +16,7 @@ resource "aws_secretsmanager_secret" "keycloak-database-password" {
 
 # if log driver is Splunk, also create Splunk token secret
 resource "aws_secretsmanager_secret" "keycloak-splunk-token" {
-  count = var.log_driver == "splunk" ? 1 : 0
+  count = var.log_driver == "splunk" && var.splunk_token_secret_arn == null ? 1 : 0
 
   name        = "keycloak-splunk-token"
   description = "Keycloak Splunk HTTP Event Collector token"

--- a/secrets.tf
+++ b/secrets.tf
@@ -9,3 +9,13 @@ resource "aws_secretsmanager_secret" "keycloak-database-password" {
 
   tags = var.tags
 }
+
+# if log driver is Splunk, also create Splunk token secret
+resource "aws_secretsmanager_secret" "keycloak-splunk-token" {
+  count = var.log_driver == "splunk" ? 1 : 0
+
+  name        = "keycloak-splunk-token"
+  description = "Keycloak Splunk HTTP Event Collector token"
+
+  tags = var.tags
+}

--- a/vars.tf
+++ b/vars.tf
@@ -71,6 +71,12 @@ variable "lb_access_logs_s3_bucket" {
   default     = null
 }
 
+variable "log_driver" {
+  type        = string
+  description = "(optional) ECS log driver for task log configuration. Supported options are 'awslogs' and 'splunk'"
+  default     = "awslogs"
+}
+
 variable "organization" {
   type        = string
   description = "The name of the organization that owns this Keycloak instance"
@@ -84,6 +90,12 @@ variable "private_subnets" {
 variable "public_subnets" {
   type        = list(string)
   description = "List of public subnets in the VPC where Keycloak will reside"
+}
+
+variable "splunk_http_endpoint" {
+  type        = string
+  description = "(optional) The Splunk HTTP endpoint to send logs to. Only required if log_driver is 'splunk'"
+  default     = null
 }
 
 variable "tags" {

--- a/vars.tf
+++ b/vars.tf
@@ -98,6 +98,12 @@ variable "splunk_http_endpoint" {
   default     = null
 }
 
+variable "splunk_token_secret_arn" {
+  type        = string
+  description = "(optional) The ARN of a Secrets Manager secret containing the Splunk token. Only required if log_driver is 'splunk' and you wish to use an existing Secrets Manager resource instead of having the module create one"
+  default     = null
+}
+
 variable "tags" {
   type        = map(string)
   description = "Map of tags to add to all resources. Defaults to `{ Project = 'Keycloak' }`"


### PR DESCRIPTION
Support configuring the ECS task's log driver from outside the module. Current valid options are `awslogs` (a.k.a. CloudWatch) and `splunk`.

Choosing the CloudWatch log driver creates a CloudWatch log group. This is the default.

Choosing the Splunk log driver requires passing a value for `splunk_http_endpoint`, and creates an additional Secrets Manager secret for the HEC token.

## Tested

Using my working copy of this branch as the value for `source` parameter on our development Keycloak cluster, I added values for `log_driver` and `splunk_http_endpoint`, then ran `terraform apply` and confirmed that the apply completed successfully and resulted in the desired configuration. I then removed the new parameters and re-applied, and confirmed that the default CloudWatch log configuration was restored.