### PR TITLE
feat: make access logging optional

### DIFF
--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -35,10 +35,15 @@ resource "aws_alb" "keycloak-load-balancer" {
   security_groups    = [aws_security_group.keycloak-load-balancer-sg.id]
 
   # LB access logs
-  access_logs {
-    bucket  = local.lb_log_bucket
-    prefix  = "keycloak-${var.environment}"
-    enabled = true
+  dynamic "access_logs" {
+    # only include this block if var.lb_enable_access_logs is true
+    for_each = var.lb_enable_access_logs == true ? toset([1]) : toset([])
+
+    content {
+      bucket  = local.lb_log_bucket
+      prefix  = "keycloak-${var.environment}"
+      enabled = var.lb_enable_access_logs
+    }
   }
 
   tags = var.tags

--- a/s3.tf
+++ b/s3.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket" "keycloak-lb-access-logs" {
-  # only create this resource if lb_access_logs_s3_bucket is null
-  count = var.lb_access_logs_s3_bucket == null ? 1 : 0
+  # only create this resource if lb_enable_access_logs is true and lb_access_logs_s3_bucket is null
+  count = var.lb_enable_access_logs == true && var.lb_access_logs_s3_bucket == null ? 1 : 0
 
   bucket        = "${lower(var.organization)}-keycloak-${var.environment}-lb-access-logs"
   force_destroy = true
@@ -9,16 +9,16 @@ resource "aws_s3_bucket" "keycloak-lb-access-logs" {
 }
 
 resource "aws_s3_bucket_acl" "keycloak-lb-access-logs" {
-  # only create this resource if lb_access_logs_s3_bucket is null
-  count = var.lb_access_logs_s3_bucket == null ? 1 : 0
+  # only create this resource if lb_enable_access_logs is true and lb_access_logs_s3_bucket is null
+  count = var.lb_enable_access_logs == true && var.lb_access_logs_s3_bucket == null ? 1 : 0
 
   bucket = aws_s3_bucket.keycloak-lb-access-logs[0].id
   acl    = "private"
 }
 
 resource "aws_s3_bucket_policy" "keycloak-lb-access-logs" {
-  # only create this resource if lb_access_logs_s3_bucket is null
-  count = var.lb_access_logs_s3_bucket == null ? 1 : 0
+  # only create this resource if lb_enable_access_logs is true and lb_access_logs_s3_bucket is null
+  count = var.lb_enable_access_logs == true && var.lb_access_logs_s3_bucket == null ? 1 : 0
 
   bucket = aws_s3_bucket.keycloak-lb-access-logs[0].id
 

--- a/vars.tf
+++ b/vars.tf
@@ -68,7 +68,7 @@ variable "kc_username" {
 variable "lb_enable_access_logs" {
   type        = bool
   description = "Whether to enable access logging to S3"
-  default     = false
+  default     = true
 }
 
 variable "lb_access_logs_s3_bucket" {

--- a/vars.tf
+++ b/vars.tf
@@ -65,9 +65,15 @@ variable "kc_username" {
   description = "Keycloak admin username"
 }
 
+variable "lb_enable_access_logs" {
+  type        = bool
+  description = "Whether to enable access logging to S3"
+  default     = false
+}
+
 variable "lb_access_logs_s3_bucket" {
   type        = string
-  description = "(optional) Name of S3 bucket where logs will be stored. Defaults to creating a new S3 bucket"
+  description = "(optional) Name of S3 bucket where logs will be stored. Defaults to creating a new S3 bucket if lb_enable_access_logs is enabled"
   default     = null
 }
 


### PR DESCRIPTION
Allow load balancer access logs to be disabled by the caller of this module. Default is still to have access logs enabled, so as to prevent this from being a breaking change.