### PR TITLE
Fix: Add storage_encryped value to db instance

### DIFF
--- a/rds.tf
+++ b/rds.tf
@@ -92,6 +92,7 @@ resource "aws_db_instance" "keycloak-database-engine" {
   skip_final_snapshot    = true
   monitoring_interval    = 15
   monitoring_role_arn    = aws_iam_role.keycloak-db-monitoring-role.arn
+  storage_encrypted      = true
 
   # this value leaks into state and thus should be changed on creation.
   # any changes are ignored by the lifecycle policy below.


### PR DESCRIPTION
Asana task: https://app.asana.com/0/0/1203868643827436/f

## Summary
This PR adds a `storage_encryped` value to the Keycloak RDS Terraform module. We are going to encrypt both keycloak-dev and keycloak-prod during the week of 2/6/23, and we'd like to have this updated module version ready to go once we complete our encryption work.  