### PR TITLE
feat (WIP): Keycloak to T-Alerts user updates SQS queue

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -71,13 +71,13 @@ data "aws_iam_policy_document" "inline-keycloak-secretsmanager-doc" {
 }
 
 # allow Keycloak to publish messages to SQS
-resource "aws_iam_role_policy" "keycloak_to_alerts_concierge_user_updates_publish" {
-  name   = "keycloak-${var.environment}-alerts-concierge-user-updates-publish"
+resource "aws_iam_role_policy" "keycloak_to_app_user_updates_publish" {
+  name   = "keycloak-${var.environment}-app-user-updates-publish"
   role   = aws_iam_role.keycloak-ecs-execution-task-role.name
-  policy = data.aws_iam_policy_document.keycloak_to_alerts_concierge_user_updates_publish.json
+  policy = data.aws_iam_policy_document.keycloak_to_app_user_updates_publish.json
 }
 
-data "aws_iam_policy_document" "keycloak_to_alerts_concierge_user_updates_publish" {
+data "aws_iam_policy_document" "keycloak_to_app_user_updates_publish" {
   statement {
     sid = "AllowSendFromKeycloak"
     effect = "Allow"
@@ -85,8 +85,6 @@ data "aws_iam_policy_document" "keycloak_to_alerts_concierge_user_updates_publis
       "sqs:GetQueueUrl",
       "sqs:SendMessage"
     ]
-    resources = [
-      aws_sqs_queue.keycloak_to_alerts_concierge_user_updates.arn
-    ]
+    resources = [ for queue in aws_sqs_queue.keycloak_to_app_user_updates : queue.arn ]
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -73,7 +73,7 @@ data "aws_iam_policy_document" "inline-keycloak-secretsmanager-doc" {
 # allow Keycloak to publish messages to SQS
 resource "aws_iam_role_policy" "keycloak_to_alerts_concierge_user_updates_publish" {
   name   = "keycloak-${var.environment}-alerts-concierge-user-updates-publish"
-  role   = resource.keycloak-service.keycloak-service.id
+  role   = aws_iam_role.keycloak-ecs-execution-task-role.name
   policy = data.aws_iam_policy_document.keycloak_to_alerts_concierge_user_updates_publish.json
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -69,3 +69,24 @@ data "aws_iam_policy_document" "inline-keycloak-secretsmanager-doc" {
     )
   }
 }
+
+# allow Keycloak to publish messages to SQS
+resource "aws_iam_role_policy" "keycloak_to_alerts_concierge_user_updates_publish" {
+  name   = "keycloak-${var.environment}-alerts-concierge-user-updates-publish"
+  role   = resource.keycloak-service.keycloak-service.id
+  policy = data.aws_iam_policy_document.keycloak_to_alerts_concierge_user_updates_publish.json
+}
+
+data "aws_iam_policy_document" "keycloak_to_alerts_concierge_user_updates_publish" {
+  statement {
+    sid = "AllowSendFromKeycloak"
+    effect = "Allow"
+    actions = [
+      "sqs:GetQueueUrl",
+      "sqs:SendMessage"
+    ]
+    resources = [
+      aws_sqs_queue.keycloak_to_alerts_concierge_user_updates.arn
+    ]
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,6 +10,6 @@ output "alb_zone_id" {
   value = aws_alb.keycloak-load-balancer.zone_id
 }
 
-output "sqs_queue_arn" {
-  value = aws_sqs_queue.keycloak_to_alerts_concierge_user_updates.arn
+output "sqs_queues" {
+  value = aws_sqs_queue.keycloak_to_app_user_updates
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,7 @@ output "alb_endpoint" {
 output "alb_zone_id" {
   value = aws_alb.keycloak-load-balancer.zone_id
 }
+
+output "sqs_queue_arn" {
+  value = aws_sqs_queue.keycloak_to_alerts_concierge_user_updates.arn
+}

--- a/sqs.tf
+++ b/sqs.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "keycloak_to_alerts_concierge_user_updates_policy
     condition {
       test     = "ArnEquals"
       variable = "aws:SourceArn"
-      values   = [aws_ecs_task_definition.keycloak-ecs-taskdef.arn]
+      values   = [aws_iam_role.keycloak-ecs-execution-task-role.arn]
     }
   }
 }

--- a/sqs.tf
+++ b/sqs.tf
@@ -2,24 +2,3 @@ resource "aws_sqs_queue" "keycloak_to_alerts_concierge_user_updates" {
   name = "keycloak-${var.environment}-alerts-concierge-user-updates"
   sqs_managed_sse_enabled = true
 }
-
-# allow Keycloak to publish messages to SQS
-resource "aws_iam_role_policy" "keycloak_to_alerts_concierge_user_updates_publish" {
-  name   = "keycloak-${var.environment}-alerts-concierge-user-updates-publish"
-  role   = resource.keycloak-service.keycloak-service.id
-  policy = data.aws_iam_policy_document.keycloak_to_alerts_concierge_user_updates_publish.json
-}
-
-data "aws_iam_policy_document" "keycloak_to_alerts_concierge_user_updates_publish" {
-  statement {
-    sid = "AllowSendFromKeycloak"
-    effect = "Allow"
-    actions = [
-      "sqs:GetQueueUrl",
-      "sqs:SendMessage"
-    ]
-    resources = [
-      aws_sqs_queue.keycloak_to_alerts_concierge_user_updates.arn
-    ]
-  }
-}

--- a/sqs.tf
+++ b/sqs.tf
@@ -4,10 +4,6 @@ resource "aws_sqs_queue" "keycloak_to_alerts_concierge_user_updates" {
 }
 
 # allow Keycloak to publish messages to SQS
-resource "aws_sqs_queue_policy" "keycloak_to_alerts_concierge_user_updates" {
-  queue_url = aws_sqs_queue.keycloak_to_alerts_concierge_user_updates.id
-  policy    = data.aws_iam_policy_document.keycloak_to_alerts_concierge_user_updates.json
-}
 resource "aws_iam_role_policy" "keycloak_to_alerts_concierge_user_updates_publish" {
   name   = "keycloak-${var.environment}-alerts-concierge-user-updates-publish"
   role   = resource.keycloak-service.keycloak-service.id

--- a/sqs.tf
+++ b/sqs.tf
@@ -13,10 +13,12 @@ resource "aws_sqs_queue_policy" "keycloak_to_app_user_updates" {
   for_each = aws_sqs_queue.keycloak_to_app_user_updates
 
   queue_url = each.value.id
-  policy    = data.aws_iam_policy_document.keycloak_to_app_user_updates_policy.json
+  policy    = data.aws_iam_policy_document.keycloak_to_app_user_updates_policy[each.key].json
 }
 
 data "aws_iam_policy_document" "keycloak_to_app_user_updates_policy" {
+  for_each = aws_sqs_queue.keycloak_to_app_user_updates
+  
   statement {
     sid = "AllowSendFromKeycloakECS"
     principals {
@@ -27,7 +29,9 @@ data "aws_iam_policy_document" "keycloak_to_app_user_updates_policy" {
       "sqs:GetQueueUrl",
       "sqs:SendMessage"
     ]
-    resources = [ for queue in aws_sqs_queue.keycloak_to_app_user_updates : queue.arn ]
+    resources = [
+      each.value.arn
+    ]
     condition {
       test     = "ArnEquals"
       variable = "aws:SourceArn"

--- a/sqs.tf
+++ b/sqs.tf
@@ -2,3 +2,30 @@ resource "aws_sqs_queue" "keycloak_to_alerts_concierge_user_updates" {
   name = "keycloak-${var.environment}-alerts-concierge-user-updates"
   sqs_managed_sse_enabled = true
 }
+
+# Allow Keycloak ECS to publish messages to SQS
+resource "aws_sqs_queue_policy" "keycloak_to_alerts_concierge_user_updates" {
+  queue_url = aws_sqs_queue.keycloak_to_alerts_concierge_user_updates.id
+  policy    = data.aws_iam_policy_document.keycloak_to_alerts_concierge_user_updates_policy.json
+}
+data "aws_iam_policy_document" "keycloak_to_alerts_concierge_user_updates_policy" {
+  statement {
+    sid = "AllowSendFromKeycloakECS"
+    principals {
+      type        = "Service"
+      identifiers = ["ecs.amazonaws.com"]
+    }
+    actions = [
+      "sqs:GetQueueUrl",
+      "sqs:SendMessage"
+    ]
+    resources = [
+      aws_sqs_queue.keycloak_to_alerts_concierge_user_updates.arn
+    ]
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [aws_ecs_task_definition.keycloak-ecs-taskdef.arn]
+    }
+  }
+}

--- a/sqs.tf
+++ b/sqs.tf
@@ -18,7 +18,10 @@ data "aws_iam_policy_document" "keycloak_to_alerts_concierge_user_updates_publis
   statement {
     sid = "AllowSendFromKeycloak"
     effect = "Allow"
-    actions = ["sqs:SendMessage"]
+    actions = [
+      "sqs:GetQueueUrl",
+      "sqs:SendMessage"
+    ]
     resources = [
       aws_sqs_queue.keycloak_to_alerts_concierge_user_updates.arn
     ]

--- a/sqs.tf
+++ b/sqs.tf
@@ -1,0 +1,26 @@
+resource "aws_sqs_queue" "keycloak_to_alerts_concierge_user_updates" {
+  name = "keycloak-${var.environment}-alerts-concierge-user-updates"
+  sqs_managed_sse_enabled = true
+}
+
+# allow Keycloak to publish messages to SQS
+resource "aws_sqs_queue_policy" "keycloak_to_alerts_concierge_user_updates" {
+  queue_url = aws_sqs_queue.keycloak_to_alerts_concierge_user_updates.id
+  policy    = data.aws_iam_policy_document.keycloak_to_alerts_concierge_user_updates.json
+}
+resource "aws_iam_role_policy" "keycloak_to_alerts_concierge_user_updates_publish" {
+  name   = "keycloak-${var.environment}-alerts-concierge-user-updates-publish"
+  role   = resource.keycloak-service.keycloak-service.id
+  policy = data.aws_iam_policy_document.keycloak_to_alerts_concierge_user_updates_publish.json
+}
+
+data "aws_iam_policy_document" "keycloak_to_alerts_concierge_user_updates_publish" {
+  statement {
+    sid = "AllowSendFromKeycloak"
+    effect = "Allow"
+    actions = ["sqs:SendMessage"]
+    resources = [
+      aws_sqs_queue.keycloak_to_alerts_concierge_user_updates.arn
+    ]
+  }
+}

--- a/vars.tf
+++ b/vars.tf
@@ -120,3 +120,9 @@ variable "vpc_id" {
   type        = string
   description = "ID of an existing VPC where Keycloak will reside"
 }
+
+variable "applications_to_update" {
+  type        = list(string)
+  description = "A list of application names that need to receive updates about user account changes."
+  default = []
+}


### PR DESCRIPTION
Asana task: [User details change notification for T-Alerts API (JMS option)](https://app.asana.com/0/1200862240523705/1204097574800019/f)

This sets up an SQS queue that allows Keycloak to publish details of user profile updates. T-Alerts will then be able to subscribe to these updates and mirror them in its local database to have the current email address and phone number for notification sending.

Encrypt the queue.

Allow Keycloak to publish to this queue. This will be followed by a PR in devops to grant alerts_concierge read permission.

## Summary

Here is a pending Terraform plan generated after bringing these changes into our man project.

<details>
<summary>Plan: 10 to add, 0 to change, 0 to destroy.</summary>
---

```
Terraform will perform the following actions:

  # module.alerts_concierge_dev.data.aws_iam_policy_document.keycloak_to_alerts_concierge_user_updates_receive will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "keycloak_to_alerts_concierge_user_updates_receive" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "sqs:DeleteMessage",
              + "sqs:GetQueueAttributes",
              + "sqs:GetQueueUrl",
              + "sqs:ReceiveMessage",
            ]
          + effect    = "Allow"
          + resources = [
              + (known after apply),
            ]
          + sid       = "AllowSendFromKeycloak"
        }
    }

  # module.alerts_concierge_dev.aws_iam_role_policy.keycloak_to_alerts_concierge_user_updates_receive will be created
  + resource "aws_iam_role_policy" "keycloak_to_alerts_concierge_user_updates_receive" {
      + id     = (known after apply)
      + name   = "keycloak-dev-alerts-concierge-user-updates-receive"
      + policy = (known after apply)
      + role   = "alerts-concierge-dev-ecs-task-role"
    }

  # module.alerts_concierge_dev_blue.data.aws_iam_policy_document.keycloak_to_alerts_concierge_user_updates_receive will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "keycloak_to_alerts_concierge_user_updates_receive" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "sqs:DeleteMessage",
              + "sqs:GetQueueAttributes",
              + "sqs:GetQueueUrl",
              + "sqs:ReceiveMessage",
            ]
          + effect    = "Allow"
          + resources = [
              + (known after apply),
            ]
          + sid       = "AllowSendFromKeycloak"
        }
    }

  # module.alerts_concierge_dev_blue.aws_iam_role_policy.keycloak_to_alerts_concierge_user_updates_receive will be created
  + resource "aws_iam_role_policy" "keycloak_to_alerts_concierge_user_updates_receive" {
      + id     = (known after apply)
      + name   = "keycloak-dev-blue-alerts-concierge-user-updates-receive"
      + policy = (known after apply)
      + role   = "alerts-concierge-dev-blue-ecs-task-role"
    }

  # module.alerts_concierge_dev_green.data.aws_iam_policy_document.keycloak_to_alerts_concierge_user_updates_receive will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "keycloak_to_alerts_concierge_user_updates_receive" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "sqs:DeleteMessage",
              + "sqs:GetQueueAttributes",
              + "sqs:GetQueueUrl",
              + "sqs:ReceiveMessage",
            ]
          + effect    = "Allow"
          + resources = [
              + (known after apply),
            ]
          + sid       = "AllowSendFromKeycloak"
        }
    }

  # module.alerts_concierge_dev_green.aws_iam_role_policy.keycloak_to_alerts_concierge_user_updates_receive will be created
  + resource "aws_iam_role_policy" "keycloak_to_alerts_concierge_user_updates_receive" {
      + id     = (known after apply)
      + name   = "keycloak-dev-green-alerts-concierge-user-updates-receive"
      + policy = (known after apply)
      + role   = "alerts-concierge-dev-green-ecs-task-role"
    }

  # module.keycloak-dev.data.aws_iam_policy_document.keycloak_to_app_user_updates_policy["alerts-concierge-dev"] will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "keycloak_to_app_user_updates_policy" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "sqs:GetQueueUrl",
              + "sqs:SendMessage",
            ]
          + resources = [
              + (known after apply),
            ]
          + sid       = "AllowSendFromKeycloakECS"

          + condition {
              + test     = "ArnEquals"
              + values   = [
                  + "arn:aws:iam::434035161053:role/keycloak-dev-ecs-execution-task-role",
                ]
              + variable = "aws:SourceArn"
            }

          + principals {
              + identifiers = [
                  + "ecs.amazonaws.com",
                ]
              + type        = "Service"
            }
        }
    }

  # module.keycloak-dev.data.aws_iam_policy_document.keycloak_to_app_user_updates_policy["alerts-concierge-dev-blue"] will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "keycloak_to_app_user_updates_policy" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "sqs:GetQueueUrl",
              + "sqs:SendMessage",
            ]
          + resources = [
              + (known after apply),
            ]
          + sid       = "AllowSendFromKeycloakECS"

          + condition {
              + test     = "ArnEquals"
              + values   = [
                  + "arn:aws:iam::434035161053:role/keycloak-dev-ecs-execution-task-role",
                ]
              + variable = "aws:SourceArn"
            }

          + principals {
              + identifiers = [
                  + "ecs.amazonaws.com",
                ]
              + type        = "Service"
            }
        }
    }

  # module.keycloak-dev.data.aws_iam_policy_document.keycloak_to_app_user_updates_policy["alerts-concierge-dev-green"] will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "keycloak_to_app_user_updates_policy" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "sqs:GetQueueUrl",
              + "sqs:SendMessage",
            ]
          + resources = [
              + (known after apply),
            ]
          + sid       = "AllowSendFromKeycloakECS"

          + condition {
              + test     = "ArnEquals"
              + values   = [
                  + "arn:aws:iam::434035161053:role/keycloak-dev-ecs-execution-task-role",
                ]
              + variable = "aws:SourceArn"
            }

          + principals {
              + identifiers = [
                  + "ecs.amazonaws.com",
                ]
              + type        = "Service"
            }
        }
    }

  # module.keycloak-dev.data.aws_iam_policy_document.keycloak_to_app_user_updates_publish will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "keycloak_to_app_user_updates_publish" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "sqs:GetQueueUrl",
              + "sqs:SendMessage",
            ]
          + effect    = "Allow"
          + resources = [
              + (known after apply),
              + (known after apply),
              + (known after apply),
            ]
          + sid       = "AllowSendFromKeycloak"
        }
    }

  # module.keycloak-dev.aws_iam_role_policy.keycloak_to_app_user_updates_publish will be created
  + resource "aws_iam_role_policy" "keycloak_to_app_user_updates_publish" {
      + id     = (known after apply)
      + name   = "keycloak-dev-app-user-updates-publish"
      + policy = (known after apply)
      + role   = "keycloak-dev-ecs-execution-task-role"
    }

  # module.keycloak-dev.aws_sqs_queue.keycloak_to_app_user_updates["alerts-concierge-dev"] will be created
  + resource "aws_sqs_queue" "keycloak_to_app_user_updates" {
      + arn                               = (known after apply)
      + content_based_deduplication       = false
      + deduplication_scope               = (known after apply)
      + delay_seconds                     = 0
      + fifo_queue                        = false
      + fifo_throughput_limit             = (known after apply)
      + id                                = (known after apply)
      + kms_data_key_reuse_period_seconds = (known after apply)
      + max_message_size                  = 262144
      + message_retention_seconds         = 345600
      + name                              = "keycloak-dev-app-user-updates-alerts-concierge-dev"
      + name_prefix                       = (known after apply)
      + policy                            = (known after apply)
      + receive_wait_time_seconds         = 0
      + redrive_allow_policy              = (known after apply)
      + redrive_policy                    = (known after apply)
      + sqs_managed_sse_enabled           = true
      + tags_all                          = (known after apply)
      + url                               = (known after apply)
      + visibility_timeout_seconds        = 30
    }

  # module.keycloak-dev.aws_sqs_queue.keycloak_to_app_user_updates["alerts-concierge-dev-blue"] will be created
  + resource "aws_sqs_queue" "keycloak_to_app_user_updates" {
      + arn                               = (known after apply)
      + content_based_deduplication       = false
      + deduplication_scope               = (known after apply)
      + delay_seconds                     = 0
      + fifo_queue                        = false
      + fifo_throughput_limit             = (known after apply)
      + id                                = (known after apply)
      + kms_data_key_reuse_period_seconds = (known after apply)
      + max_message_size                  = 262144
      + message_retention_seconds         = 345600
      + name                              = "keycloak-dev-app-user-updates-alerts-concierge-dev-blue"
      + name_prefix                       = (known after apply)
      + policy                            = (known after apply)
      + receive_wait_time_seconds         = 0
      + redrive_allow_policy              = (known after apply)
      + redrive_policy                    = (known after apply)
      + sqs_managed_sse_enabled           = true
      + tags_all                          = (known after apply)
      + url                               = (known after apply)
      + visibility_timeout_seconds        = 30
    }

  # module.keycloak-dev.aws_sqs_queue.keycloak_to_app_user_updates["alerts-concierge-dev-green"] will be created
  + resource "aws_sqs_queue" "keycloak_to_app_user_updates" {
      + arn                               = (known after apply)
      + content_based_deduplication       = false
      + deduplication_scope               = (known after apply)
      + delay_seconds                     = 0
      + fifo_queue                        = false
      + fifo_throughput_limit             = (known after apply)
      + id                                = (known after apply)
      + kms_data_key_reuse_period_seconds = (known after apply)
      + max_message_size                  = 262144
      + message_retention_seconds         = 345600
      + name                              = "keycloak-dev-app-user-updates-alerts-concierge-dev-green"
      + name_prefix                       = (known after apply)
      + policy                            = (known after apply)
      + receive_wait_time_seconds         = 0
      + redrive_allow_policy              = (known after apply)
      + redrive_policy                    = (known after apply)
      + sqs_managed_sse_enabled           = true
      + tags_all                          = (known after apply)
      + url                               = (known after apply)
      + visibility_timeout_seconds        = 30
    }

  # module.keycloak-dev.aws_sqs_queue_policy.keycloak_to_app_user_updates["alerts-concierge-dev"] will be created
  + resource "aws_sqs_queue_policy" "keycloak_to_app_user_updates" {
      + id        = (known after apply)
      + policy    = (known after apply)
      + queue_url = (known after apply)
    }

  # module.keycloak-dev.aws_sqs_queue_policy.keycloak_to_app_user_updates["alerts-concierge-dev-blue"] will be created
  + resource "aws_sqs_queue_policy" "keycloak_to_app_user_updates" {
      + id        = (known after apply)
      + policy    = (known after apply)
      + queue_url = (known after apply)
    }

  # module.keycloak-dev.aws_sqs_queue_policy.keycloak_to_app_user_updates["alerts-concierge-dev-green"] will be created
  + resource "aws_sqs_queue_policy" "keycloak_to_app_user_updates" {
      + id        = (known after apply)
      + policy    = (known after apply)
      + queue_url = (known after apply)
    }

Plan: 10 to add, 0 to change, 0 to destroy.
```

---
</details>

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204179871611976