### PR TITLE
Fix: Ignore minor RDS engine version changes

### DIFF
--- a/rds.tf
+++ b/rds.tf
@@ -81,7 +81,7 @@ resource "aws_db_instance" "keycloak-database-engine" {
   allocated_storage      = 20
   max_allocated_storage  = 100
   engine                 = "mariadb"
-  engine_version         = "10.5.12"
+  engine_version         = "10"
   instance_class         = "db.t3.micro"
   db_subnet_group_name   = local.db_subnet_group
   multi_az               = true

--- a/rds.tf
+++ b/rds.tf
@@ -81,7 +81,7 @@ resource "aws_db_instance" "keycloak-database-engine" {
   allocated_storage      = 20
   max_allocated_storage  = 100
   engine                 = "mariadb"
-  engine_version         = "10"
+  engine_version         = "10.5"
   instance_class         = "db.t3.micro"
   db_subnet_group_name   = local.db_subnet_group
   multi_az               = true


### PR DESCRIPTION
No Asana task. Noticed drift in both `dev` and `prod` modules. 

## Summary
This PR is the first step to resolve unintentional drift by ignoring minor RDS engine version changes. It's technically a no-op, since we need to update the `source` in the DevOps repo to trigger any Terraform changes.

## Checklist
- [ ] Merge this change
- [ ] Publish new version of this repo and tag it appropriately
- [ ] Open PR to update the `source` for both `keycloak_dev` and `keycloak_prod` in the DevOps repo