### PR TITLE
Fix: Update DB URL

### DIFF
--- a/keycloak.tf
+++ b/keycloak.tf
@@ -59,7 +59,7 @@ resource "aws_ecs_task_definition" "keycloak-ecs-taskdef" {
       "environment": [
         {"name":"KEYCLOAK_ADMIN", "value":"${var.kc_username}"},
         {"name":"KC_DB", "value":"mariadb"},
-        {"name":"KC_DB_URL", "value":"jdbc:mysql://${data.aws_db_instance.database.endpoint}/${var.db_name}?autoReconnect=true"},
+        {"name":"KC_DB_URL", "value":"jdbc:mysql://${aws_db_instance.keycloak-database-engine.endpoint}/${var.db_name}?autoReconnect=true"},
         {"name":"KC_DB_USERNAME", "value":"${var.db_username}"},
         {"name":"KC_HTTP_RELATIVE_PATH", "value":"/auth"},
         {"name":"KC_CACHE_CONFIG_FILE", "value":"cache-ispn-jdbc-ping.xml"},


### PR DESCRIPTION
The `KC DB URL` value should be set from `aws_db_instance.keycloak-database-engine`, unfortunately this was missed during PR review by me. 