### PR TITLE
feat: add tags to some additional locations

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -17,6 +17,8 @@ resource "aws_cloudwatch_metric_alarm" "keycloak-alarm-scale-down" {
     ClusterName = local.keycloak_ecs_cluster_name
     ServiceName = aws_ecs_service.keycloak-service.name
   }
+
+  tags = var.tags
 }
 
 # CLOUDWATCH ALARM  to monitor memory utilization of a service
@@ -38,6 +40,8 @@ resource "aws_cloudwatch_metric_alarm" "keycloak-alarm-scale-up" {
     ClusterName = local.keycloak_ecs_cluster_name
     ServiceName = aws_ecs_service.keycloak-service.name
   }
+
+  tags = var.tags
 }
 
 resource "aws_appautoscaling_target" "keycloak-ecs-target" {
@@ -46,6 +50,8 @@ resource "aws_appautoscaling_target" "keycloak-ecs-target" {
   resource_id        = "service/${local.keycloak_ecs_cluster_name}/${aws_ecs_service.keycloak-service.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
+
+  tags = var.tags
 }
 
 # Set up the memory utilization policy for scale down when the cloudwatch alarm gets triggered.
@@ -85,4 +91,3 @@ resource "aws_appautoscaling_policy" "keycloak-policy-scale-up" {
     }
   }
 }
-

--- a/keycloak.tf
+++ b/keycloak.tf
@@ -141,6 +141,8 @@ resource "aws_ecs_service" "keycloak-service" {
     ]
   }
 
+  tags = var.tags
+
   depends_on = [aws_lb_listener.keycloak-listener, aws_iam_role.keycloak-ecs-execution-task-role, aws_db_instance.keycloak-database-engine]
 }
 

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -86,6 +86,8 @@ resource "aws_lb_listener" "keycloak-listener" {
     type             = "forward"
     target_group_arn = aws_lb_target_group.keycloak-target-group.id
   }
+
+  tags = var.tags
 }
 
 resource "aws_lb_listener_rule" "redirect_to_mbta_com" {
@@ -104,11 +106,11 @@ resource "aws_lb_listener_rule" "redirect_to_mbta_com" {
   }
   condition {
     path_pattern {
-      values      = ["/"]
+      values = ["/"]
     }
   }
-  tags = {
-    project     = "MBTA-Keycloak"
-    Name        = "Redirect-to-MBTA-page"
-  }
+
+  tags = merge(var.tags, {
+    Name = "Redirect-to-MBTA-page"
+  })
 }

--- a/sqs.tf
+++ b/sqs.tf
@@ -3,9 +3,11 @@ resource "aws_sqs_queue" "keycloak_to_app_user_updates" {
     for app in var.applications_to_update
     : app => app
   }
-  
-  name = "keycloak-${var.environment}-app-user-updates-${each.key}"
+
+  name                    = "keycloak-${var.environment}-app-user-updates-${each.key}"
   sqs_managed_sse_enabled = true
+
+  tags = var.tags
 }
 
 # Allow Keycloak ECS to publish messages to SQS
@@ -18,7 +20,7 @@ resource "aws_sqs_queue_policy" "keycloak_to_app_user_updates" {
 
 data "aws_iam_policy_document" "keycloak_to_app_user_updates_policy" {
   for_each = aws_sqs_queue.keycloak_to_app_user_updates
-  
+
   statement {
     sid = "AllowSendFromKeycloakECS"
     principals {


### PR DESCRIPTION
These missing locations prevent us from using tag-based permissions for managing the Keycloak resources.

Blocking mbta/devops#1764