### PR TITLE
Feat: Scaffolding for RDS auto backups

### DIFF
--- a/rds.tf
+++ b/rds.tf
@@ -93,6 +93,7 @@ resource "aws_db_instance" "keycloak-database-engine" {
   monitoring_interval    = 15
   monitoring_role_arn    = aws_iam_role.keycloak-db-monitoring-role.arn
   storage_encrypted      = true
+  backup_retention_period = var.backup_retention_period
 
   # this value leaks into state and thus should be changed on creation.
   # any changes are ignored by the lifecycle policy below.

--- a/vars.tf
+++ b/vars.tf
@@ -131,3 +131,9 @@ variable "applications_to_update" {
   description = "A list of application names that need to receive updates about user account changes."
   default = []
 }
+
+variable "backup_retention_period" {
+  type        = number
+  description = "How long to store RDS DB backups"
+  default     = null
+}


### PR DESCRIPTION
This PR enables us to set a retention period for Keycloak. Without this ability, we aren't able to automatically backup the RDS DB. The retention period defaults to `null` and we'll manually set the prod retention period to 7 days. 

Post-merge checklist:
- [ ] Cut a new release (v1.1.0)
- [ ] Update Keycloak dev and prod to the new release, also updating prod with a retention period of 7 days