### PR TITLE
Provider version constraint updated

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.66.0"
+      version = ">= 4.66.0"
     }
   }
 }


### PR DESCRIPTION
I needed to change the AWS provider constraint from ~> 4.66.0 to >= 4.66.0 so that custom modules in devops repository could pull this in and satisfy version constraints.  We were getting this when planning in aws-tid-main-base:

```
Could not retrieve the list of available versions for provider hashicorp/aws: no 
available releases match the given constraints ~> 4.66.0, ~> 5.82.0
```