### PR TITLE
Adjust loadbalancer healthcheck settings

### DIFF
--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -66,10 +66,10 @@ resource "aws_lb_target_group" "keycloak-target-group" {
     interval            = "300"
     protocol            = "HTTP"
     matcher             = "200"
-    timeout             = "3"
+    timeout             = "10"
     path                = "/auth/health"
     port                = 9000
-    unhealthy_threshold = "2"
+    unhealthy_threshold = "3"
   }
 
   tags = var.tags


### PR DESCRIPTION
This change basically sets the default values for HTTP load balancer. It should help to avoid 504 error during deployment.  
I'm expecting that the timeout value was too short which could lead to intermittent 504 error.  
On the sandbox, we re-ran load test again, no 504 errors occurred.