### PR TITLE
chore: update memory and enable LB access logs

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -3,8 +3,9 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.66.1"
-  constraints = "~> 4.66.0"
+  constraints = ">= 4.66.0"
   hashes = [
+    "h1:AqQpXqwPd3bejoduTzc82UhMCzwirWE9I8hUOLsJDXY=",
     "h1:D/qzK7fE3pgdg25W1u5GqI+VILy8UmhzXruz6c8rJ7g=",
     "zh:001c707174b7d6bf89a96cf806f925bb852d1a285fb80b81222cbeb4743bcb79",
     "zh:19bc6ac0a7fd1c564fd56c536f1743f71a5e7ca724e21ea51a6a79218939733d",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version = "3.6.3"
   hashes = [
     "h1:Fnaec9vA8sZ8BXVlN3Xn9Jz3zghSETIKg7ch8oXhxno=",
+    "h1:f6jXn4MCv67kgcofx9D49qx1ZEBv8oyvwKDMPBr0A24=",
     "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
     "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
     "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
@@ -46,6 +48,7 @@ provider "registry.terraform.io/hashicorp/random" {
 provider "registry.terraform.io/hashicorp/tls" {
   version = "4.0.6"
   hashes = [
+    "h1:/sSdjHoiykrPdyBP1JE03V/KDgLXnHZhHcSOYIdDH/A=",
     "h1:dYSb3V94K5dDMtrBRLPzBpkMTPn+3cXZ/kIJdtFL+2M=",
     "zh:10de0d8af02f2e578101688fd334da3849f56ea91b0d9bd5b1f7a243417fdda8",
     "zh:37fc01f8b2bc9d5b055dc3e78bfd1beb7c42cfb776a4c81106e19c8911366297",

--- a/iam.tf
+++ b/iam.tf
@@ -83,12 +83,12 @@ resource "aws_iam_role_policy" "keycloak_to_app_user_updates_publish" {
 
 data "aws_iam_policy_document" "keycloak_to_app_user_updates_publish" {
   statement {
-    sid = "AllowSendFromKeycloak"
+    sid    = "AllowSendFromKeycloak"
     effect = "Allow"
     actions = [
       "sqs:GetQueueUrl",
       "sqs:SendMessage"
     ]
-    resources = [ for queue in aws_sqs_queue.keycloak_to_app_user_updates : queue.arn ]
+    resources = [for queue in aws_sqs_queue.keycloak_to_app_user_updates : queue.arn]
   }
 }

--- a/keycloak.tf
+++ b/keycloak.tf
@@ -101,8 +101,8 @@ resource "aws_ecs_task_definition" "keycloak-ecs-taskdef" {
 
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  memory                   = "2048"
-  cpu                      = "512"
+  memory                   = "4096"
+  cpu                      = "1024"
   execution_role_arn       = aws_iam_role.keycloak-ecs-execution-task-role.arn
   task_role_arn            = aws_iam_role.keycloak-ecs-execution-task-role.arn
 

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -34,16 +34,12 @@ resource "aws_alb" "keycloak-load-balancer" {
   subnets            = var.public_subnets
   security_groups    = [aws_security_group.keycloak-load-balancer-sg.id]
 
-  # LB access logs
-  dynamic "access_logs" {
-    # only include this block if var.lb_enable_access_logs is true
-    for_each = var.lb_enable_access_logs == true ? toset([1]) : toset([])
 
-    content {
-      bucket  = local.lb_log_bucket
-      prefix  = "keycloak-${var.environment}"
-      enabled = var.lb_enable_access_logs
-    }
+  # LB access logs
+  access_logs {
+    bucket  = local.lb_log_bucket
+    prefix  = "keycloak-${var.environment}"
+    enabled = var.lb_enable_access_logs
   }
 
   tags = var.tags

--- a/main.tf
+++ b/main.tf
@@ -3,12 +3,12 @@ provider "aws" {
 }
 
 terraform {
-  required_version = ">= 1.0.8"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.0"
+      version = ">= 5.86.0"
     }
   }
 }

--- a/rds.tf
+++ b/rds.tf
@@ -76,23 +76,23 @@ resource "aws_db_option_group" "rds-mariadb-og" {
 }
 
 resource "aws_db_instance" "keycloak-database-engine" {
-  db_name                = var.db_name
-  identifier             = "keycloak-${var.environment}"
-  allocated_storage      = 20
-  max_allocated_storage  = 100
-  engine                 = "mariadb"
-  engine_version         = "10.5"
-  instance_class         = "db.t3.micro"
-  db_subnet_group_name   = local.db_subnet_group
-  multi_az               = true
-  username               = var.db_username
-  parameter_group_name   = "rds-keycloak-${var.environment}-mariadb-pg"
-  option_group_name      = "rds-keycloak-${var.environment}-mariadb-og"
-  vpc_security_group_ids = [aws_security_group.database-sg.id]
-  skip_final_snapshot    = true
-  monitoring_interval    = 15
-  monitoring_role_arn    = aws_iam_role.keycloak-db-monitoring-role.arn
-  storage_encrypted      = true
+  db_name                 = var.db_name
+  identifier              = "keycloak-${var.environment}"
+  allocated_storage       = 20
+  max_allocated_storage   = 100
+  engine                  = "mariadb"
+  engine_version          = "10.5"
+  instance_class          = "db.t3.micro"
+  db_subnet_group_name    = local.db_subnet_group
+  multi_az                = true
+  username                = var.db_username
+  parameter_group_name    = "rds-keycloak-${var.environment}-mariadb-pg"
+  option_group_name       = "rds-keycloak-${var.environment}-mariadb-og"
+  vpc_security_group_ids  = [aws_security_group.database-sg.id]
+  skip_final_snapshot     = true
+  monitoring_interval     = 15
+  monitoring_role_arn     = aws_iam_role.keycloak-db-monitoring-role.arn
+  storage_encrypted       = true
   backup_retention_period = var.backup_retention_period
 
   # this value leaks into state and thus should be changed on creation.

--- a/vars.tf
+++ b/vars.tf
@@ -129,7 +129,7 @@ variable "vpc_id" {
 variable "applications_to_update" {
   type        = list(string)
   description = "A list of application names that need to receive updates about user account changes."
-  default = []
+  default     = []
 }
 
 variable "backup_retention_period" {


### PR DESCRIPTION
Attempted fix of recent 504 timeouts. While we aren't seeing any crashing tasks, bumping CPU and memory seems like a reasonable attempt based off metrics that show CPU maxed out and no memory available in the ECS console. 

This PR also enables access logs, which aren't currently enabled despite the logic below. I've removed the logic, since we want logs enabled in both dev and prod. 