### PR TITLE
Allow Keycloak access logs

### DIFF
--- a/keycloak.tf
+++ b/keycloak.tf
@@ -73,7 +73,11 @@ resource "aws_ecs_task_definition" "keycloak-ecs-taskdef" {
         {"name":"KC_PROXY", "value":"edge"},
         {"name":"KC_HEALTH_ENABLED", "value":"true"},
         {"name":"JAVA_OPTS_APPEND", "value":"-Xmx${local.keycloak_java_memory}m -DawsRegion=${var.aws_region} -DawsJmsQueues=${var.aws_jms_queues}"},
-        {"name":"KC_PROXY_HEADERS", "value":"xforwarded"}
+        {"name":"KC_PROXY_HEADERS", "value":"xforwarded"},
+        {"name":"QUARKUS_HTTP_ACCESS_LOG_ENABLED", "value":"${var.accessLog_enabled}"},
+        {"name":"QUARKUS_HTTP_ACCESS_LOG_PATTERN", "value":"%t [%%{i,X-Forwarded-For}, %h] %l (user:%u) - '%r' => %s (%b bytes) '%%{i,User-Agent}' (Referer '%%{i,Referer}') - [%I, %Dms]"},
+        {"name":"QUARKUS_HTTP_ACCESS_LOG_CONSOLIDATE_REROUTED_REQUESTS", "value":"${var.accessLog_consolidate}"},
+        {"name":"QUARKUS_HTTP_RECORD_REQUEST_START_TIME", "value":"${var.accessLog_recordStartTime}"}
       ],
       "secrets": [
         {"name":"KEYCLOAK_ADMIN_PASSWORD", "valueFrom":"${aws_secretsmanager_secret.keycloak-admin-password.arn}"},

--- a/vars.tf
+++ b/vars.tf
@@ -137,3 +137,21 @@ variable "backup_retention_period" {
   description = "How long to store RDS DB backups"
   default     = null
 }
+
+variable "accessLog_enabled" {
+  type        = bool
+  description = "Enables Keycloak access log"
+  default     = false
+}
+
+variable "accessLog_consolidate" {
+  type        = bool
+  description = "Enables HTTP rerouted requests consolidation"
+  default     = false
+}
+
+variable "accessLog_recordStartTime" {
+  type        = bool
+  description = "Enables HTTP request elapsed time in milliseconds"
+  default     = false
+}


### PR DESCRIPTION
By default Keycloak access log is disabled. Turning it on can be done in terraform.tfvars as usual.