### PR TITLE
Rollout per single task

### DIFF
--- a/keycloak.tf
+++ b/keycloak.tf
@@ -153,6 +153,7 @@ resource "aws_ecs_service" "keycloak-service" {
   scheduling_strategy  = "REPLICA"
   desired_count        = 2
   force_new_deployment = true
+  deployment_maximum_percent = 150
 
   network_configuration {
     subnets          = var.private_subnets


### PR DESCRIPTION
Sets maximum of running tasks during the deployment. In this case 3 tasks. Which leads to step-by-step rollout.