### PR TITLE
fix: ensure inter-node communication on `jdbc-ping` ports

### DIFF
--- a/keycloak.tf
+++ b/keycloak.tf
@@ -167,13 +167,13 @@ resource "aws_ecs_task_definition" "keycloak-ecs-taskdef" {
 }
 
 resource "aws_ecs_service" "keycloak-service" {
-  name                 = "keycloak-${var.environment}"
-  cluster              = local.keycloak_ecs_cluster_arn
-  task_definition      = aws_ecs_task_definition.keycloak-ecs-taskdef.arn
-  launch_type          = "FARGATE"
-  scheduling_strategy  = "REPLICA"
-  desired_count        = 2
-  force_new_deployment = true
+  name                       = "keycloak-${var.environment}"
+  cluster                    = local.keycloak_ecs_cluster_arn
+  task_definition            = aws_ecs_task_definition.keycloak-ecs-taskdef.arn
+  launch_type                = "FARGATE"
+  scheduling_strategy        = "REPLICA"
+  desired_count              = 2
+  force_new_deployment       = true
   deployment_maximum_percent = 150
 
   network_configuration {

--- a/keycloak.tf
+++ b/keycloak.tf
@@ -46,7 +46,7 @@ resource "aws_security_group" "keycloak-sg" {
 
   # https://www.keycloak.org/server/caching#network-ports
   ingress {
-    description = "allow inter-process communication for Infinispan dbc-ping"
+    description = "allow communication for distributed caching using Infinispan + jdbc-ping"
     from_port   = 7800
     to_port     = 7800
     protocol    = "tcp"
@@ -54,7 +54,7 @@ resource "aws_security_group" "keycloak-sg" {
   }
 
   ingress {
-    description = "allow inter-process communication for Infinispan dbc-ping"
+    description = "allow failure detection for distributed caching using Infinispan + jdbc-ping"
     from_port   = 57800
     to_port     = 57800
     protocol    = "tcp"

--- a/keycloak.tf
+++ b/keycloak.tf
@@ -44,6 +44,23 @@ resource "aws_security_group" "keycloak-sg" {
     security_groups = [aws_security_group.keycloak-load-balancer-sg.id]
   }
 
+  # https://www.keycloak.org/server/caching#network-ports
+  ingress {
+    description = "allow inter-process communication for Infinispan dbc-ping"
+    from_port   = 7800
+    to_port     = 7800
+    protocol    = "tcp"
+    self        = true
+  }
+
+  ingress {
+    description = "allow inter-process communication for Infinispan dbc-ping"
+    from_port   = 57800
+    to_port     = 57800
+    protocol    = "tcp"
+    self        = true
+  }
+
   egress {
     description      = "Allow external traffic to the internet"
     from_port        = 0
@@ -105,12 +122,16 @@ resource "aws_ecs_task_definition" "keycloak-ecs-taskdef" {
           "hostPort": 8080
         },
         {
-          "containerPort": 7600,
-          "hostPort": 7600
+          "containerPort": 7800,
+          "hostPort": 7800
         },
         {
           "containerPort": 9000,
           "hostPort": 9000
+        },
+        {
+          "containerPort": 57800,
+          "hostPort": 57800
         }
       ],
       "cpu": ${local.keycloak_task_cpu},


### PR DESCRIPTION
Changing `deployment_maximum_percent` to `150` in https://github.com/mbta/terraform-keycloak-sso/pull/49 did not resolve our deploy turbulence issue, so we're continuing to explore other solutions. 

According to Keycloak's guide to [configuring distributed caches](https://www.keycloak.org/server/caching#network-ports), the default configuration for Infinispan's `jdbc-ping` transport stack uses port `7800` for data transmission and `57800` for failure detection. We only had port `7600` configured in the Keycloak task definition, which may have been used by a previous version of Keycloak. Additionally, the security group used by Keycloak ECS tasks was not configured to allow direct communication between tasks, so it's likely that our Keycloak deployments have never been able to form a cluster in the first place.

This change addresses the following:

- Changes the container port mapping for `jdbc-ping` from port `7600` to `7800`
- Adds a port mapping for failure detection on port `57800`
- Adds security group rules to allow communication on ports `7800` and `57800` within the cluster
- Fixes an unrelated formatting issue from https://github.com/mbta/terraform-keycloak-sso/pull/49

H/T to @krisrjohnson21 for first raising the port configuration theory!